### PR TITLE
Satisfy mypy requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,7 @@ version = "0.0.1"
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["dcpgis*"]
+
+[[tool.mypy.overrides]]
+module = ["arcpy.*"]
+follow_untyped_imports = true

--- a/utilities/powershell/deploy_esri_py_env_pro.ps1
+++ b/utilities/powershell/deploy_esri_py_env_pro.ps1
@@ -11,7 +11,7 @@
         numpy version to satisfy geopandas is 1.22. These will change as we upgrade to higher 
         versions of ArcGIS Pro.
 #>
-$newEnvName = 'gis-team-default-env'
+$newEnvName = 'gis-env'
 $baseEnvName = 'arcgispro-py3'
 $numpyVersion = 1.22
 
@@ -65,6 +65,10 @@ pip install --user numpy==$numpyVersion
 
 Write-Output "`r`n>>> pip installing fiona..."
 pip install fiona
+
+# install items to satisfy mypy and type-hinting requirements
+Write-Output "`r`n>>> Installing mypy package stubs..."
+conda install pandas-stubs
 
 Write-Output "`r`n>>> Listing all conda environments..."
 conda info --envs


### PR DESCRIPTION
mypy has been raising issues with my environment. I did two things to resolve this:
1. Added a `conda install pandas-stubs` line to the default environment powershell script
2. Added a line to the pyproject.toml to ignore mypy errors related to arcpy, since it seems like there's no stub package available for arcpy. We can resolve this further later I think

I also changed the name of the default env to `gis-env` for the sake of brevity and terminal space. Happy to amend this further as needed.