### PR TITLE
Explore methods to run a pipeline that calls multiple python envs

### DIFF
--- a/experiments/multi_env/README.md
+++ b/experiments/multi_env/README.md
@@ -1,0 +1,23 @@
+# Exploring use of a multi environment pipeline
+
+## Context
+Most of the Python tools used by the DCP GIS Team use virtual environments based off of the default conda installation that comes with ArcGIS Pro. Much of our data exists in the Esri ecosystem, and having access to `arcpy`, `arcgis`, and other Esri-specific packages is important.
+
+This limits us to the version of Python that is packaged with ArcGIS Pro (e.g. Pro 3.5 ships with Python 3.11.11). Often there are alternative open source tools that we would like to use to replace Esri's methods, such as Data Engineering's `dcpy` package. This causes issues if we want to run tools based on the Python 3.13-based `dcpy`, while our default conda environment is pinned to 3.11.
+
+This experiment is intended to prove the viability of a single pipeline based around multiple versions of Python. 
+
+An example of a problem this could solve is: accessing and transforming some dataset using Esri's conda, calling `dcpy` to generate up to date metadata for that dataset, and then using Esri's conda to write that dataset to an endpoint like an enterprise geodatabase.
+
+Some benefits include being able to call tools from different Python versions, being able to "sandwich" `dcpy`-based processing in between Esri-based processing, and keeping the whole pipeline in Python for simplicity.
+
+Alternate approaches could use a more mature orchestration tool that calls different Python interpreters for different tasks, or simply using bash/PowerShell to orchestrate the pipeline.
+
+## Execution
+ (assumes that the repo root is the current working directory)
+
+- Create the non-conda virtual envirnment by running `build.ps1`
+
+- Call pipeline via `python experiments\multi_env\pipeline_runner.py`
+
+- Examine console outputs

--- a/experiments/multi_env/build.ps1
+++ b/experiments/multi_env/build.ps1
@@ -1,0 +1,11 @@
+$REPO_NAME = "data-engineering"
+$VENV = ".venv"
+
+conda activate arcgispro-py3
+
+# Make .venv
+Write-Host "Creating a new Python virtual environment"
+conda create --prefix "$PSScriptRoot\$VENV" python=3.13 -c conda-forge
+
+# Install dcpy
+& "$PSScriptRoot\.venv\Scripts\pip.exe" install "git+https://github.com/NYCPlanning/data-engineering.git" --no-warn-script-location 

--- a/experiments/multi_env/part_a.py
+++ b/experiments/multi_env/part_a.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import shutil
+import sys
+import platform
+import arcpy
+
+
+def part_a(data_dir: Path, shp_name):
+
+    print("Part A: Creating shapefile with arcpy/conda-based env")
+    print(f"\tPython version: {platform.python_version()}")
+    print(f"\tFile: {__file__}")
+    print(f"\tInterpreter: {sys.executable}")
+
+    if data_dir.is_dir():
+        shutil.rmtree(data_dir)
+    data_dir.mkdir()
+    arcpy.management.CreateFeatureclass(str(data_dir), shp_name)
+
+    return data_dir / shp_name

--- a/experiments/multi_env/part_b.py
+++ b/experiments/multi_env/part_b.py
@@ -1,0 +1,33 @@
+from dcpy.utils.geospatial import shapefile
+from pathlib import Path
+import sys
+import platform
+
+
+def part_b():
+    """Generate new metadata and write it to a shapefile"""
+    print("Part B: Writing metadata with dcpy-based environment")
+    print(f"\tPython version: {platform.python_version()}")
+    print(f"\tFile: {__file__}")
+    print(f"\tInterpreter: {sys.executable}")
+
+    if len(sys.argv) < 2:
+        print("Error: No input file provided", file=sys.stderr)
+        return 1
+    input_shp = Path(sys.argv[1])
+    shp_name = input_shp.name
+
+    md = shapefile.generate_metadata()
+
+    shp = shapefile.Shapefile(path=input_shp.parent, shp_name=shp_name)
+
+    shp.write_metadata(md, overwrite=True)
+
+    # metadata = shp.read_metadata()
+
+    # print(metadata)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(part_b())

--- a/experiments/multi_env/part_c.py
+++ b/experiments/multi_env/part_c.py
@@ -1,0 +1,23 @@
+import xml.etree.ElementTree as ET
+import sys
+import platform
+
+
+def part_c(item_path):
+    """Return the CreaDate and CreaTime elements from shapefile metadata"""
+
+    print("Part C: Getting creation time with arcpy/conda-based env")
+    print(f"\tPython version: {platform.python_version()}")
+    print(f"\tFile: {__file__}")
+    print(f"\tInterpreter: {sys.executable}")
+
+    md_path = str(item_path) + ".xml"
+    tree = ET.parse(md_path)
+    root = tree.getroot()
+    crea_time_element = root.find("./Esri/CreaTime")
+    crea_date_element = root.find("./Esri/CreaDate")
+
+    print("\tCreation timestamp values from new metadata:")
+    print(
+        f"\t\tCreaDate: {crea_date_element.text}\n\t\tCreaTime: {crea_time_element.text}"
+    )

--- a/experiments/multi_env/pipeline_runner.py
+++ b/experiments/multi_env/pipeline_runner.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import subprocess
+import shutil
+import time
+
+import arcpy
+
+from part_a import part_a
+from part_c import part_c
+
+
+VENV2_PYTHON = Path(__file__).parent / ".venv/python.exe"
+PART_B_PY = Path(__file__).parent / "part_b.py"
+DATA_DIR = Path(__file__).parent / "data"
+
+
+def remove_esri_data_dir(dir: Path):
+    arcpy.ClearWorkspaceCache_management()
+    time.sleep(0.2)
+    shutil.rmtree(dir)
+
+
+def main():
+
+    shp_path = DATA_DIR / "temp.shp"
+
+    # Part A, called from arcpy/conda env
+    input_file = part_a(data_dir=DATA_DIR, shp_name=shp_path.name)
+
+    # Part B, called from dcpy env
+    subprocess.run(
+        [str(VENV2_PYTHON), "-I", PART_B_PY, str(input_file)],
+        # capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Part C, called from arcpy/conda env again
+    part_c(item_path=shp_path)
+
+    remove_esri_data_dir(DATA_DIR)  # comment me out to examine temp.shp.xml outputs
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In which we explore an approach to integrating calls to `dcpy` within an `arcpy`-based pipeline.

For testing
- clone and switch to this dev branch
- run `build.ps1` to get everything set up on your machine to run the test pipeline. This file also helps to show what commands we need to run to set up a `dcpy`-based virtual env on our Windows machines
- run pipeline via `python pipeline_runner.py`. Obviously change relative to the directory you have active
- pipeline interacts with the three `part_*.py` files and prints output to console

I tried to re-write the code to be a little more intuitive and parseable.

tagging @NYCPlanning/gis for review, and @damonmcc in case you're interested. We'll seek more DE approval after we've digested some ideas internally